### PR TITLE
Add a callback to get notified when SharedTextureManager has been (re)initialized

### DIFF
--- a/SharedTexture.cpp
+++ b/SharedTexture.cpp
@@ -365,6 +365,8 @@ void SharedTextureManager::initGL()
 {
 	for (auto& s : senders) s->initGL();
 	for (auto& r : receivers) r->initGL();
+
+	listeners.call(&Listener::GLInitialized);
 }
 
 void SharedTextureManager::renderGL()

--- a/SharedTexture.h
+++ b/SharedTexture.h
@@ -146,6 +146,7 @@ public:
 		virtual ~Listener() {}
 		virtual void receiverRemoved(SharedTextureReceiver *) {}
 		virtual void senderRemoved(SharedTextureSender *) {}
+		virtual void GLInitialized() {}
 	};
 
 	ListenerList<Listener> listeners;


### PR DESCRIPTION
Classes that want to register senders through SharedTextureManager might be interested to know when SharedTextureManager::initGL() is has been called.

For example:
SomeClass calls SharedTextureManager::addSender to write to a texture. 
An event happens somewhere that call SharedTextureManager::clearGL, all senders are remove and SomeClass gets notified. 
If at some point SharedTextureManager::initGL is called, SomeClass might be interested to have this info and to try to call SharedTextureManager::addSender again.